### PR TITLE
Add tile imagery for maps

### DIFF
--- a/_data/site_config.yml
+++ b/_data/site_config.yml
@@ -92,21 +92,22 @@ frontpage_cards:
     rule_color: ''
   - title: Publications & Useful resources
     content: >
- 
-      [National Strategy for the Development of Statistics III (NSDS III)](https://zimstats.devpreview.net/about_us/nsds/)
-      
-      
-      [Zimbabwe Peer Review of the National Statistical System Report](https://www.zimstat.co.zw/wp-content/uploads/nss/2023/ZIMBABWE_NSS_PEER_REVIEW_REPORT.pdf)
- 
- 
-      [The Sustainable Development Goals in Zimbabwe](https://zimbabwe.un.org/en)
-      
+
+      [National Strategy for the Development of Statistics III (NSDS
+      III)](https://zimstats.devpreview.net/about_us/nsds/)
+
+
+      [Zimbabwe Peer Review of the National Statistical System
+      Report](https://www.zimstat.co.zw/wp-content/uploads/nss/2023/ZIMBABWE_NSS_PEER_REVIEW_REPORT.pdf)
+
+
+      [The Sustainable Development Goals in
+      Zimbabwe](https://zimbabwe.un.org/en)
+
 
       [The Global Goals](https://www.globalgoals.org/)
- 
+
       <br/><br/>
- 
-      
     include: ''
     button_label: Publications
     button_link: https://sdg-zimbabwe.github.io/site/news/
@@ -162,30 +163,22 @@ languages:
 languages_public: []
 logos: []
 map_layers:
-    # The subfolder under 'geojson' in the data repository holding the GeoJSON files:
   - subfolder: regions
-    # The label to use in the "Download GeoJSON" button:
     label: indicator.map
-    # The minimum zoom at which this layer should be visible.
-    # For example, if this "min_zoom" is set to 4, then this
-    # layer will be invisible at zoom level 3 or less.
     min_zoom: 0
-    # The maximum zoom at which this layer should be visible.
-    # For example, if this "max_zoom" is set to 8, then this
-    # layer will be invisible at zoom level 9 or more.
     max_zoom: 20
-    # Whether or not these boundaries should display statically
-    # on lower layers.
     staticBorders: false
 map_options:
   disaggregation_controls: false
   minZoom: 5
   maxZoom: 10
-  tileURL: ''
+  tileURL: https://tile.openstreetmap.org/{z}/{x}/{y}.png
   tileOptions:
     id: ''
     accessToken: ''
-    attribution: ''
+    attribution: >-
+      &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>
+      contributors
   colorRange: chroma.brewer.BuGn
   noValueColor: '#f0f0f0'
   styleNormal:
@@ -205,7 +198,6 @@ map_options:
     opacity: 1
     fillOpacity: 0
     color: '#172d44'
-    dashArray: 5,5
 menu:
   - path: /
     translation_key: general.home


### PR DESCRIPTION
These changes were generated using the site config form, which seems to have included a few unrelated changes which should be harmless.

The purpose of this PR is to add OpenStreetMaps tile imagery to the maps. This is definitely NOT required and it would be fine to close this PR without merging if the OpenStreetMaps tile imagery is not wanted. Here is a link to the OpenStreetMaps tile usage policy: https://operations.osmfoundation.org/policies/tiles/